### PR TITLE
Update   para software config

### DIFF
--- a/fmrilab_softwareconfig.sh
+++ b/fmrilab_softwareconfig.sh
@@ -20,7 +20,6 @@ apt install ssh sshfs \
   python-is-python3 python3-matplotlib python3-numpy \
   xfonts xfonts-base xfonts-100dpi 
 
-
 ## Apps a instalar
 apt install xterm tilix \
   shutter \
@@ -32,15 +31,9 @@ apt install xterm tilix \
 	# terminator \ terminal padre pero se isntala por encima del default
 
 apt autoremove
-  
-  
-  
 
-## Librerias para otros sofware (mrtrix, fsl, etc.)
-### MRtrix3 (git g++ python-is-python3 instalados en miscelaneos)
-apt-get install libeigen3 zlib1g libqt5opengl5 libqt5svg5 libgl1-mesa libfftw3 libtiff5 libpng
-### Afni
-apt-get install gsl-bin libcurl4-openssl-dev libgdal-dev libglw1-mesa libjpeg62 libnode-dev libopenblas-dev libudunits2-dev libxm4 libxml2-dev
+
+
 
 # PPA SOFTWARE
 
@@ -58,6 +51,7 @@ apt-get install gsl-bin libcurl4-openssl-dev libgdal-dev libglw1-mesa libjpeg62 
 	add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
 
 	apt install --no-install-recommends r-base r-base-dev
+
 
 
 
@@ -84,25 +78,38 @@ deb-get install code \
 	onlyoffice-desktopeditors
 
 
-# NEUROSTUFF SOFTWARE aditional steps
-
-# para fsl 509
-# apt install libmng-dev
-#ln -sv /usr/lib/x86_64-linux-gnu/libmng.so.2 /usr/lib/x86_64-linux-gnu/libmng.so.1
-#ln -sv /usr/lib/x86_64-linux-gnu/libjpeg.so.8 /usr/lib/x86_64-linux-gnu/libjpeg.so.62
-#f=`locate libpng12.so.0 | head -n 1`
-#cp -v $f /usr/lib/x86_64-linux-gnu/
 
 
-# para mrtrix
-# apt install libgtkglext1
-#f=/usr/lib/x86_64-linux-gnu/libgsl.so.23
-#ln -sv $f /usr/lib/x86_64-linux-gnu/libgsl.so.0
 
-# para freesurfer 5.3
+# NEUROSTUFF SOFTWARE
 
-# para afni
-ln -s /usr/lib/x86_64-linux-gnu/libgsl.so.23 /usr/lib/x86_64-linux-gnu/libgsl.so.19
+## Librerias requeridas
+### MRtrix3 (git g++ python-is-python3 instalados en miscelaneos)
+apt-get install libeigen3 zlib1g libqt5opengl5 libqt5svg5 libgl1-mesa libfftw3 libtiff5 libpng
+### Afni
+apt-get install gsl-bin libcurl4-openssl-dev libgdal-dev libglw1-mesa libjpeg62 libnode-dev libopenblas-dev libudunits2-dev libxm4 libxml2-dev
+
+## Pasos adicionales
+	# para fsl 509
+	# apt install libmng-dev
+	#ln -sv /usr/lib/x86_64-linux-gnu/libmng.so.2 /usr/lib/x86_64-linux-gnu/libmng.so.1
+	#ln -sv /usr/lib/x86_64-linux-gnu/libjpeg.so.8 /usr/lib/x86_64-linux-gnu/libjpeg.so.62
+	#f=`locate libpng12.so.0 | head -n 1`
+	#cp -v $f /usr/lib/x86_64-linux-gnu/
+
+
+	# para mrtrix
+	# apt install libgtkglext1
+	#f=/usr/lib/x86_64-linux-gnu/libgsl.so.23
+	#ln -sv $f /usr/lib/x86_64-linux-gnu/libgsl.so.0
+
+	# para freesurfer 5.3
+
+	# para afni
+	ln -s /usr/lib/x86_64-linux-gnu/libgsl.so.23 /usr/lib/x86_64-linux-gnu/libgsl.so.19
+
+
+
 
 
 # removing .deb in /tmp

--- a/fmrilab_softwareconfig.sh
+++ b/fmrilab_softwareconfig.sh
@@ -28,11 +28,12 @@ apt install xterm tilix \
   x2goclient x2goserver \
   vim
   
-	# terminator \ terminal padre pero se isntala por encima del default
+	# terminator \ terminal padre pero se instala por encima del default
 
 apt autoremove
 
-
+### añadidos para mrtrix y afni: python-is-python3 python3-matplotlib python3-numpy 
+### añadidos para afni: tcsh, xfonts-base, xfonts-100dpi
 
 
 # PPA SOFTWARE
@@ -61,7 +62,7 @@ apt autoremove
 #Install deb-get
 curl -sL https://raw.githubusercontent.com/wimpysworld/deb-get/main/deb-get | sudo -E bash -s install deb-get
 
-#deb-get install rstudio \ Hay un big en deb-get para esto, revisar si ya fue resuleto
+#deb-get install rstudio \ Hay un bug en deb-get para esto, revisar si ya fue resuleto
 
 deb-get install code \
 	rclone \

--- a/fmrilab_softwareconfig.sh
+++ b/fmrilab_softwareconfig.sh
@@ -18,7 +18,7 @@ apt install ssh sshfs \
   apcupsd \
   gnome-tweaks gnome-shell-extensions \
   python-is-python3 python3-matplotlib python3-numpy \
-  xfonts xfonts-base xfonts-100dpi 
+  xfonts-base xfonts-100dpi 
 
 ## Apps a instalar
 apt install xterm tilix \
@@ -83,36 +83,40 @@ deb-get install code \
 
 # NEUROSTUFF SOFTWARE
 
-## Librerias requeridas
-### MRtrix3 (git g++ python-is-python3 instalados en miscelaneos)
-apt-get install libeigen3 zlib1g libqt5opengl5 libqt5svg5 libgl1-mesa libfftw3 libtiff5 libpng
-### Afni
-apt-get install gsl-bin libcurl4-openssl-dev libgdal-dev libglw1-mesa libjpeg62 libnode-dev libopenblas-dev libudunits2-dev libxm4 libxml2-dev
+## MRtrix3 (git g++ python-is-python3 instalados en miscelaneos)
+apt-get install zlib1g libqt5opengl5 libqt5svg5 libtiff5 libeigen3-dev libgl1-mesa-dev libfftw3-dev libpng-dev
+	# en las instrucciones de mrtrix todos eran packetes -dev  
 
-## Pasos adicionales
-	# para fsl 509
-	# apt install libmng-dev
-	#ln -sv /usr/lib/x86_64-linux-gnu/libmng.so.2 /usr/lib/x86_64-linux-gnu/libmng.so.1
-	#ln -sv /usr/lib/x86_64-linux-gnu/libjpeg.so.8 /usr/lib/x86_64-linux-gnu/libjpeg.so.62
-	#f=`locate libpng12.so.0 | head -n 1`
-	#cp -v $f /usr/lib/x86_64-linux-gnu/
+## Afni
+apt-get install gsl-bin libcurl4-openssl-dev libgdal-dev libglw1-mesa libjpeg62 libnode-dev libopenblas-dev libudunits2-dev libxm4 libxml2-dev libssl-dev
+	# faltan apra el 22.04  libgfortran4 libgfortran-8-dev
+#### link simbolico que afni requiere
+ln -s /usr/lib/x86_64-linux-gnu/libgsl.so.23 /usr/lib/x86_64-linux-gnu/libgsl.so.19
 
 
-	# para mrtrix
-	# apt install libgtkglext1
-	#f=/usr/lib/x86_64-linux-gnu/libgsl.so.23
-	#ln -sv $f /usr/lib/x86_64-linux-gnu/libgsl.so.0
-
-	# para freesurfer 5.3
-
-	# para afni
-	ln -s /usr/lib/x86_64-linux-gnu/libgsl.so.23 /usr/lib/x86_64-linux-gnu/libgsl.so.19
+# para fsl 509
+# apt install libmng-dev
+#ln -sv /usr/lib/x86_64-linux-gnu/libmng.so.2 /usr/lib/x86_64-linux-gnu/libmng.so.1
+#ln -sv /usr/lib/x86_64-linux-gnu/libjpeg.so.8 /usr/lib/x86_64-linux-gnu/libjpeg.so.62
+#f=`locate libpng12.so.0 | head -n 1`
+#cp -v $f /usr/lib/x86_64-linux-gnu/
 
 
+# para mrtrix (version anteior?)
+# apt install libgtkglext1
+#f=/usr/lib/x86_64-linux-gnu/libgsl.so.23
+#ln -sv $f /usr/lib/x86_64-linux-gnu/libgsl.so.0
+
+# para freesurfer 5.3
 
 
 
-# removing .deb in /tmp
+
+
+
+# Terminando la instalacion
+
+## removing .deb in /tmp
 rm -f -v /tmp/*.deb
 
 echo "[finished installing software]"

--- a/fmrilab_softwareconfig.sh
+++ b/fmrilab_softwareconfig.sh
@@ -89,7 +89,7 @@ apt-get install zlib1g libqt5opengl5 libqt5svg5 libtiff5 libeigen3-dev libgl1-me
 
 ## Afni
 apt-get install gsl-bin libcurl4-openssl-dev libgdal-dev libglw1-mesa libjpeg62 libnode-dev libopenblas-dev libudunits2-dev libxm4 libxml2-dev libssl-dev
-	# faltan apra el 22.04  libgfortran4 libgfortran-8-dev
+	# faltan para el 22.04  libgfortran4 libgfortran-8-dev
 #### link simbolico que afni requiere
 ln -s /usr/lib/x86_64-linux-gnu/libgsl.so.23 /usr/lib/x86_64-linux-gnu/libgsl.so.19
 

--- a/fmrilab_softwareconfig.sh
+++ b/fmrilab_softwareconfig.sh
@@ -4,36 +4,43 @@
 
 ## miscelaneos a instalar
 apt install ssh sshfs \
+  git \
   wget \
   htop \
   byobu \
   tree \
-  x2goclient x2goserver \
   xvfb \
   parallel \
   build-essential \
+  cmake \
   curl \
   gdebi-core\
   apcupsd \
   gnome-tweaks gnome-shell-extensions \
-  python-is-python3
+  python-is-python3 python3-matplotlib python3-numpy \
+  xfonts xfonts-base xfonts-100dpi 
 
 
 ## Apps a instalar
-apt install tilix \
-  terminator \
+apt install xterm tilix \
   shutter \
-  inkscape
+  inkscape \
+  tcsh \
+  x2goclient x2goserver \
+  vim
   
+	# terminator \ terminal padre pero se isntala por encima del default
+
 apt autoremove
   
   
   
 
 ## Librerias para otros sofware (mrtrix, fsl, etc.)
-# MRtrix3 (git g++ python-is-python3 instalados en miscelaneos)
+### MRtrix3 (git g++ python-is-python3 instalados en miscelaneos)
 apt-get install libeigen3 zlib1g libqt5opengl5 libqt5svg5 libgl1-mesa libfftw3 libtiff5 libpng
-
+### Afni
+apt-get install gsl-bin libcurl4-openssl-dev libgdal-dev libglw1-mesa libjpeg62 libnode-dev libopenblas-dev libudunits2-dev libxm4 libxml2-dev
 
 # PPA SOFTWARE
 
@@ -73,10 +80,11 @@ deb-get install code \
 	bitwarden keepassxc \
 	sejda-desktop \
 	rocketchat \
-	bat lsd duf fd
+	bat lsd duf fd \
+	onlyoffice-desktopeditors
 
 
-# NEUROSTUFF SOFTWARE
+# NEUROSTUFF SOFTWARE aditional steps
 
 # para fsl 509
 # apt install libmng-dev
@@ -92,8 +100,9 @@ deb-get install code \
 #ln -sv $f /usr/lib/x86_64-linux-gnu/libgsl.so.0
 
 # para freesurfer 5.3
-# apt install tcsh
 
+# para afni
+ln -s /usr/lib/x86_64-linux-gnu/libgsl.so.23 /usr/lib/x86_64-linux-gnu/libgsl.so.19
 
 
 # removing .deb in /tmp


### PR DESCRIPTION
-  Organicé en 4 secciones para instalación de software: miscelaneos, ppa, deb-get y neruosoftware.

- En miscelaneos 
   -- En micelaneos deje unos comentarios de que cosas extra añaden mrtrix3 y afni, pero igual es software que sirve en general
   --agregue git que se me habia pasado

- En neurosofwate esta lo necesario para mrtrix3 y afni. 
   --Lo de afni no ha funcionado en ubuntu 22.04, podemos comentar ambas lineas hasta que funcione jeje.

