### PR TITLE
Profile.d modifications

### DIFF
--- a/client_22-04.md
+++ b/client_22-04.md
@@ -182,8 +182,6 @@ Y reiniciamos el servidor NFS
 
 
 
-
-
 # Configurar software
 El software está centralizado. Algunas librerías y dependencias cambiaron entre ubuntu 14.04 y 18.04. Para arreglarlo, corremos el script
 ```
@@ -200,13 +198,27 @@ Simplemente copiar la instalación de otra máquina. Eso ya incluye la licencia 
 sudo rsync -avz --partial --progress  soporte@mansfield:/usr/local/MATLAB /usr/local/
 ```
 
-Ya casi vamos a rebootear, así que ahora:
+## Singularity
+Nada más correr el script `fmrilab_config_singularity.sh`, que lo único que hace es una carpeta en /opt para que ahí quede el localstatedir (ver [aquí](https://singularity.lbl.gov/admin-guide) para más info).
+
+
+# Configurar fmrilab_profile
+
+Copiamos fmrilab_profile.sh a /etc/profile.d . Este script contiene las configuraciones de arranque para las máquinas en don clusterio. Por el momento solo consifte en exportar la variable de sistema FMRILAB_CONFIGFILE que tiene todo los paths de los software 
+```
+./fmrilab_config_profile.sh
+```
+
+
+# reboot
+
+Antes de reebotear una actualizacion del software y despues reboot
 ```
 apt update
 apt upgrade
+apt reboot
 ```
 
-# reboot
 
 
 # SGE
@@ -244,8 +256,7 @@ Es opcional, pero a mí me gusta cambiar el número máximo de slots para correr
 qconf -aattr queue slots “[NEWHOSTNAME.inb.unam.mx=7]" all.q
 ```
 
-## Singularity
-Nada más correr el script `fmrilab_config_singularity.sh`, que lo único que hace es una carpeta en /opt para que ahí quede el localstatedir (ver [aquí](https://singularity.lbl.gov/admin-guide) para más info).
+
 
 
 

--- a/fmrilab_config_nis.sh
+++ b/fmrilab_config_nis.sh
@@ -34,9 +34,6 @@ echo "Editando /etc/yp.conf"
 echo "ypserver 172.24.80.102" >> /etc/yp.conf
 
 
-echo "Editando /etc/profile"
-cat ./fmrilab_profile >> /etc/profile
-
 echo "Editando /lib/systemd/system/systemd-logind.service "
 
 sed -i 's/^IPAddressDeny=any/#IPAddressDeny=any/' /lib/systemd/system/systemd-logind.service

--- a/fmrilab_config_profile.sh
+++ b/fmrilab_config_profile.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+
+# export the fmrilab_profile file into profile.d
+cp ./fmrilab_profile.sh /etc/profile.d
+
+

--- a/fmrilab_profile.sh
+++ b/fmrilab_profile.sh
@@ -1,4 +1,4 @@
-
+# This file runs initial configuration for a don_clusterio session
 
 if [ $(id -gn) = "fmriuser" ]; then
 	export FMRILAB_CONFIGFILE=/home/inb/soporte/admin_tools/fmrilab_configfile


### PR DESCRIPTION
Erase /etc/profile bit from config_nis scripts. 
Add new config script to copy fmrilab_profile.sh to etc/profile.d so it can run from a session. 
Add this step to wiki to config new machine